### PR TITLE
Ksp 0.21 fix

### DIFF
--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -279,7 +279,7 @@ public class ExLaunchPad : PartModule
                     ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
                     ShipConstruction.PutShipToGround(nship, this.part.transform);
                     // is this line causing bug #11 ?
-                    ShipConstruction.AssembleForLaunch(nship, "External Launchpad", HighLogic.CurrentGame.flagURL, state);
+                    ShipConstruction.AssembleForLaunch(nship, "External Launchpad", HighLogic.CurrentGame.flagURL, HighLogic.CurrentGame, null);
                     Staging.beginFlight();
                     nship.parts[0].vessel.ResumeStaging();
                     Staging.GenerateStagingSequence(nship.parts[0].localRoot);

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -275,7 +275,6 @@ public class ExLaunchPad : PartModule
                 {
 
                     // build craft
-                    FlightState state = new FlightState();
                     ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
                     ShipConstruction.PutShipToGround(nship, this.part.transform);
                     // is this line causing bug #11 ?


### PR DESCRIPTION
This is a fix to get EPL compiling and working (or so it seems) with KSP 0.21.1. The fix was simply correcting the call to ShipConstruction.AssembleForLaunch, but I am not certain I used the correct Game instance for the state parameter, though my basic testing showed things to be working (including spawning a new ship).
