### PR TITLE
Resource density

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/Resources/ExtraSpaceCenters.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Resources/ExtraSpaceCenters.cfg
@@ -29,8 +29,8 @@ KethaneResource
   Resource = Ore
   MinRadius = 7.29
   MaxRadius = 16.2
-  MinQuantity = 10000
-  MaxQuantity = 500000
+  MinQuantity = 400000
+  MaxQuantity = 20000000
   MinVertices = 20
   MaxVertices = 50
   RadiusVariance = 0.45
@@ -43,8 +43,8 @@ KethaneResource
     // Gilly is mostly carbon
     name = Gilly
     DepositCount = 5
-    MinQuantity = 2000
-    MaxQuantity = 50000
+    MinQuantity = 80000
+    MaxQuantity = 2000000
   }
   Body
   {
@@ -61,7 +61,7 @@ KethaneResource
     DepositCount = 30
     MinRadius = 2.5
     MaxRadius = 8
-    MaxQuantity = 20000
+    MaxQuantity = 800000
   }
   Body
   {
@@ -69,8 +69,8 @@ KethaneResource
   	name = Duna
   	DepositCount = 30
   	MaxRadius = 50
-  	MinQuantity = 100000
-  	MaxQuantity = 1000000
+	MinQuantity = 4000000
+	MaxQuantity = 40000000
   	NumberOfTries = 50
   }
   Body
@@ -79,7 +79,7 @@ KethaneResource
   	name = Dres
   	DepositCount = 25
   	MaxRadius = 20
-  	MaxQuantity = 1000000
+	MaxQuantity = 40000000
   }
   Body
   {
@@ -93,15 +93,15 @@ KethaneResource
   	name = Laythe
   	DepositCount = 25
   	MaxRadius = 30
-  	MinQuantity = 100000
-  	MaxQuantity = 1000000
+	MinQuantity = 4000000
+	MaxQuantity = 40000000
   }
   Body
   {
   	// Tylo is covered in a rhyolite layer of rock, nickel, a little cobalt, some sort of ice and dust
   	name = Tylo
   	DepositCount = 10
-  	MinQuantity = 2000
+	MinQuantity = 80000
   	NumberOfTries = 5
   }
   Body
@@ -110,8 +110,8 @@ KethaneResource
   	name = Bop
   	DepositCount = 30
   	MaxRadius = 50
-  	MinQuantity = 1000000
-  	MaxQuantity = 10000000
+	MinQuantity = 40000000
+	MaxQuantity = 400000000
   	NumberOfTries = 50
   }
   Body
@@ -119,8 +119,8 @@ KethaneResource
   	// Pol is covered in phosphoric or sulfuric compounds
   	name = Pol
   	DepositCount = 10
-  	MinQuantity = 100
-  	MaxQuantity = 20000
+	MinQuantity = 4000
+	MaxQuantity = 800000
   }
   Body
   {

--- a/GameData/ExtraplanetaryLaunchpads/Resources/ExtraSpaceCenters.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Resources/ExtraSpaceCenters.cfg
@@ -1,7 +1,9 @@
+//These densities work on the assumption that 1m^3 holds 200u of resource.
+
 RESOURCE_DEFINITION
 {
   name = RocketParts
-  density = 1
+  density = 0.0025		// parts are very fluffy. 0.5t/m^3
   flowMode = ALL_VESSEL
   transfer = PUMP
 }
@@ -9,7 +11,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = Metal
-  density = 1
+  density = 0.039		// iron is 7.8t/m^3
   flowMode = ALL_VESSEL
   transfer = PUMP
 }
@@ -17,7 +19,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = Ore
-  density = 1
+  density = 0.0275			// average density of rock is 5.5t/m^3
   flowMode = ALL_VESSEL
   transfer = PUMP
 }

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -631,10 +631,14 @@ public class ExLaunchPad : PartModule
 		rpdef = PartResourceLibrary.Instance.GetDefinition("RocketParts");
         resources.Add("RocketParts", mass / rpdef.density);
 
+
         // If Solid Fuel is used, convert to RocketParts
         if (resources.ContainsKey("SolidFuel"))
         {
-            resources["RocketParts"] += resources["SolidFuel"]*0.0075f;
+			PartResourceDefinition sfdef;
+			sfdef = PartResourceLibrary.Instance.GetDefinition("SolidFuel");
+			float sfmass = resources["SolidFuel"] * sfdef.density;
+            resources["RocketParts"] += sfmass / rpdef.density;
             resources.Remove("SolidFuel");
         }
 

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -627,7 +627,9 @@ public class ExLaunchPad : PartModule
                 }
             }
         }
-        resources.Add("RocketParts", mass);
+		PartResourceDefinition rpdef;
+		rpdef = PartResourceLibrary.Instance.GetDefinition("RocketParts");
+        resources.Add("RocketParts", mass / rpdef.density);
 
         // If Solid Fuel is used, convert to RocketParts
         if (resources.ContainsKey("SolidFuel"))


### PR DESCRIPTION
These are my changes to bring the size of the resource unit in line with the rest of KSP (ie, about 200u per cubic meter), and thus give the ore, metal and rocket parts resources sensible densities. As part of the process, I also tweaked the conversion ratios for ort->metal and metal->rocket parts, but as those files are not in git, here are the relevant lines:

smelter:
    // From http://en.wikipedia.org/wiki/Iron_ore
    // Stage One: 3 Fe2O3 + CO → 2 Fe3O4 + CO2
    // Stage Two: Fe3O4 + CO → 3 FeO + CO2
    // Stage Three: FeO + CO → Fe + CO2
    //
    // Until Kethane supports multiple input/output resources, no point in
    // worrying about CO/CO2.
    //
    // So 3Fe2O3 + 9CO → 6Fe + 9CO2, Fe = 55.845, O = 15.999 which means
    // 479.061g of ore will produce 335.070g of iron. Kethane takes care of the
    // relative densities for us, thus the efficiency is just 355.07/479.061.
    ConversionEfficiency = 0.699431

workshop:
    // There is always some waste when building things (sawing, grinding,
    // cutoffs, etc).
    ConversionEfficiency = 0.9
