### PR TITLE
Pad fix

### DIFF
--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -114,22 +114,6 @@ public class ExLaunchPad : PartModule
 		Staging.beginFlight();
 
 		UseResources(nship);
-
-		//Remove the kerbals who get spawned with the ship
-		/*foreach (Part p in nship.parts)
-		{
-			if (p.CrewCapacity > 0)
-			{
-				print("Part has crew");
-				foreach (ProtoCrewMember m in p.protoModuleCrew)
-				{
-					print("Removing crewmember:");
-					print(m.name);
-					p.RemoveCrewmember(m);
-					m.rosterStatus = ProtoCrewMember.RosterStatus.AVAILABLE;
-				}
-			}
-		}*/
 	}
 
     private void WindowGUI(int windowID)

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -103,7 +103,7 @@ public class ExLaunchPad : PartModule
 	private void FixCraftLock()
 	{
 		// Many thanks to Snjo (firespitter)
-		uis.vessel.situation = Vessel.Situations.PRELAUNCH;
+		uis.vessel.situation = Vessel.Situations.LANDED;
 		uis.vessel.state = Vessel.State.ACTIVE;
 		uis.vessel.Landed = true;
 		uis.vessel.Splashed = false;

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -119,6 +119,8 @@ public class ExLaunchPad : PartModule
 
 		ShipConstruction.AssembleForLaunch(nship, landedAt, flag, state, crew);
 
+		Vessel vessel = FlightGlobals.ActiveVessel;
+		vessel.Landed = false;
 
 		Staging.beginFlight();
 	}

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -100,6 +100,7 @@ public class ExLaunchPad : PartModule
 	{
 		// build craft
 		ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
+		UseResources(nship);
 
 		Transform t = this.part.transform;
 		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
@@ -112,8 +113,6 @@ public class ExLaunchPad : PartModule
 		FlightGlobals.ActiveVessel.transform.position = nt.position;
 
 		Staging.beginFlight();
-
-		UseResources(nship);
 	}
 
     private void WindowGUI(int windowID)

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -33,6 +33,7 @@ public class ExLaunchPad : PartModule
         public bool canbuildcraft = false;
         public crafttype ct = crafttype.VAB;
         public string craftfile = null;
+        public string flagname = null;
         public CraftBrowser craftlist = null;
         public bool showcraftbrowser = false;
         public ConfigNode craftnode = null;
@@ -106,7 +107,7 @@ public class ExLaunchPad : PartModule
 		Transform t = this.part.transform;
 
 		string landedAt = "External Launchpad";
-		string flag = FlightDriver.newShipFlagURL;
+		string flag = uis.flagname;
 		Game state = FlightDriver.FlightStateCache;
 		VesselCrewManifest crew = new VesselCrewManifest ();
 
@@ -399,6 +400,7 @@ public class ExLaunchPad : PartModule
     {
         uis.showcraftbrowser = false;
         uis.craftfile = filename;
+        uis.flagname = flagname;
         uis.craftnode = ConfigNode.Load(filename);
         ConfigNode[] nodes = uis.craftnode.GetNodes("PART");
 

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -102,20 +102,23 @@ public class ExLaunchPad : PartModule
 		ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
 		UseResources(nship);
 
+		Vector3 offset = Vector3.up * SpawnHeightOffset;
 		Transform t = this.part.transform;
-		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
+
 		string landedAt = "External Launchpad";
 		string flag = FlightDriver.newShipFlagURL;
 		Game state = FlightDriver.FlightStateCache;
 		VesselCrewManifest crew = new VesselCrewManifest ();
 
-		ShipConstruction.CreateBackup(nship);
-		ShipConstruction.PutShipToGround(nship, t);
+		GameObject launchPos = new GameObject ();
+		launchPos.transform.position = t.position;
+		launchPos.transform.position += t.TransformDirection(offset);
+		launchPos.transform.rotation = t.rotation;
+		ShipConstruction.PutShipToGround(nship, launchPos.transform);
+		Destroy(launchPos);
+
 		ShipConstruction.AssembleForLaunch(nship, landedAt, flag, state, crew);
 
-		Transform nt = t;
-		nt.position += nt.TransformDirection(Vector3.up) * SpawnHeightOffset;
-		FlightGlobals.ActiveVessel.transform.position = nt.position;
 
 		Staging.beginFlight();
 	}

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -41,6 +41,9 @@ public class ExLaunchPad : PartModule
         public Vector2 resscroll;
         public Dictionary<string, float> requiredresources = null;
         public Dictionary<string, float> resourcesliders = new Dictionary<string, float>();
+
+		public float timer;
+		public Vessel vessel;
     }
 
 	[KSPField(isPersistant = false)]
@@ -97,6 +100,20 @@ public class ExLaunchPad : PartModule
 		}
 	}
 
+	private void FixCraftLock()
+	{
+		// Many thanks to Snjo (firespitter)
+		uis.vessel.situation = Vessel.Situations.PRELAUNCH;
+		uis.vessel.state = Vessel.State.ACTIVE;
+		uis.vessel.Landed = true;
+		uis.vessel.Splashed = false;
+		uis.vessel.GoOnRails();
+		uis.vessel.rigidbody.WakeUp();
+		uis.vessel.ResumeStaging();
+		uis.vessel.landedAt = "External Launchpad";
+		InputLockManager.ClearControlLocks();
+	}
+
 	private void BuildAndLaunchCraft()
 	{
 		// build craft
@@ -124,6 +141,9 @@ public class ExLaunchPad : PartModule
 		vessel.Landed = false;
 
 		Staging.beginFlight();
+
+		uis.timer = 3.0f;
+		uis.vessel = vessel;
 	}
 
     private void WindowGUI(int windowID)
@@ -489,6 +509,19 @@ public class ExLaunchPad : PartModule
         }
     }
     */
+
+	public void Update()
+	{
+		if (uis.vessel && uis.timer >= 0)
+		{
+			uis.timer -= Time.deltaTime;
+			if (uis.timer <= 0)
+			{
+				FixCraftLock();
+				uis.vessel = null;
+			}
+		}
+	}
 
     // Fired ONCE per frame
     public override void OnUpdate()

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -52,23 +52,8 @@ public class ExLaunchPad : PartModule
     // =====================================================================================================================================================
     // UI Functions
 
-	private void BuildAndLaunchCraft()
+	private void UseResources(ShipConstruct nship)
 	{
-		// build craft
-		ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
-
-		Transform t = this.part.transform;
-		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
-		Vessel ov = FlightGlobals.ActiveVessel;
-		ShipConstruction.CreateBackup(nship);
-		ShipConstruction.PutShipToGround(nship, t);
-		Transform nt = t;
-		ShipConstruction.AssembleForLaunch(nship, "External Launchpad", FlightDriver.newShipFlagURL, FlightDriver.FlightStateCache, new VesselCrewManifest());
-		nt.position += nt.TransformDirection(Vector3.up) * SpawnHeightOffset;
-		FlightGlobals.ActiveVessel.transform.position = nt.position;
-
-		Staging.beginFlight();
-
 		// use resources
 		foreach (KeyValuePair<string, float> pair in uis.requiredresources)
 		{
@@ -109,6 +94,26 @@ public class ExLaunchPad : PartModule
 			}
 			*/
 		}
+	}
+
+	private void BuildAndLaunchCraft()
+	{
+		// build craft
+		ShipConstruct nship = ShipConstruction.LoadShip(uis.craftfile);
+
+		Transform t = this.part.transform;
+		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
+		Vessel ov = FlightGlobals.ActiveVessel;
+		ShipConstruction.CreateBackup(nship);
+		ShipConstruction.PutShipToGround(nship, t);
+		Transform nt = t;
+		ShipConstruction.AssembleForLaunch(nship, "External Launchpad", FlightDriver.newShipFlagURL, FlightDriver.FlightStateCache, new VesselCrewManifest());
+		nt.position += nt.TransformDirection(Vector3.up) * SpawnHeightOffset;
+		FlightGlobals.ActiveVessel.transform.position = nt.position;
+
+		Staging.beginFlight();
+
+		UseResources(nship);
 
 		//Remove the kerbals who get spawned with the ship
 		/*foreach (Part p in nship.parts)

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -104,7 +104,6 @@ public class ExLaunchPad : PartModule
 
 		Transform t = this.part.transform;
 		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
-		Vessel ov = FlightGlobals.ActiveVessel;
 		string landedAt = "External Launchpad";
 		string flag = FlightDriver.newShipFlagURL;
 		Game state = FlightDriver.FlightStateCache;

--- a/Launchpad/ExLaunchPad.cs
+++ b/Launchpad/ExLaunchPad.cs
@@ -105,10 +105,16 @@ public class ExLaunchPad : PartModule
 		Transform t = this.part.transform;
 		t.position += t.TransformDirection(Vector3.up) * SpawnHeightOffset;
 		Vessel ov = FlightGlobals.ActiveVessel;
+		string landedAt = "External Launchpad";
+		string flag = FlightDriver.newShipFlagURL;
+		Game state = FlightDriver.FlightStateCache;
+		VesselCrewManifest crew = new VesselCrewManifest ();
+
 		ShipConstruction.CreateBackup(nship);
 		ShipConstruction.PutShipToGround(nship, t);
+		ShipConstruction.AssembleForLaunch(nship, landedAt, flag, state, crew);
+
 		Transform nt = t;
-		ShipConstruction.AssembleForLaunch(nship, "External Launchpad", FlightDriver.newShipFlagURL, FlightDriver.FlightStateCache, new VesselCrewManifest());
 		nt.position += nt.TransformDirection(Vector3.up) * SpawnHeightOffset;
 		FlightGlobals.ActiveVessel.transform.position = nt.position;
 


### PR DESCRIPTION
This set of commits stops the spawned craft from being forced to ground _through_ the launchpad. Unfortunately, the spawned craft does not work yet as controls seem to be locked. Going to the space center and back to the craft allows some control, but the throttle gets stuck at about 10%. Still, no more explosions with an appropriate SpawnHeightOffset.

The code has been refactored a little and the spawned craft's flag is now set correctly.
