### PR TITLE
Use MODEL nodes for the recycling bin.

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/Parts/RecycleBin/part.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Parts/RecycleBin/part.cfg
@@ -3,7 +3,12 @@ PART {
 	module = Part
 	author = Bill Currie
 
-	mesh = recyclebin-large.mu
+	MODEL {
+		model = Extraplanetary Launchpads/Parts/RecycleBin/recyclebin
+		position	=	0.0, 0.0, 0.0
+		rotation	=	0.0, 0.0, 0.0
+		scale		=	1.0, 1.0, 1.0
+	}
 	rescaleFactor = 1.0
 	scale = 1.0
 
@@ -39,7 +44,12 @@ PART {
 	module = Part
 	author = Bill Currie
 
-	mesh = recyclebin.mu
+	MODEL {
+		model = Extraplanetary Launchpads/Parts/RecycleBin/recyclebin-large
+		position	=	0.0, 0.0, 0.0
+		rotation	=	0.0, 0.0, 0.0
+		scale		=	1.0, 1.0, 1.0
+	}
 	rescaleFactor = 1.0
 	scale = 1.0
 


### PR DESCRIPTION
Also, correct the swapping of the large and small bins.

It turns out that "mesh" is deprecated because it doesn't actually do what
it says. This fixes the small recycling bin getting the large bin's model.

NOTE: in this version, the EL directory in GameData _MUST_ be
"Extraplanetary Launchpads" or the bins will not load.
